### PR TITLE
feat: add JSONSchema support for structured output

### DIFF
--- a/client.go
+++ b/client.go
@@ -499,6 +499,7 @@ func (c *Client) toGeneratedRunRequest(req *RunRequest) *models.RunRequest {
 		genReq.Claude.DangerouslySkipPermissions = req.Claude.DangerouslySkipPermissions
 		genReq.Claude.PermissionMode = req.Claude.PermissionMode
 		genReq.Claude.OutputFormat = req.Claude.OutputFormat
+		genReq.Claude.JSONSchema = req.Claude.JSONSchema
 		genReq.Claude.Verbose = req.Claude.Verbose
 		genReq.Claude.Debug = req.Claude.Debug
 		genReq.Claude.Continue = req.Claude.Continue

--- a/types.go
+++ b/types.go
@@ -203,6 +203,31 @@ type ClaudeOptions struct {
 	// Values: "text", "json", "stream-json"
 	OutputFormat string `json:"output_format,omitempty"`
 
+	// JSONSchema specifies a JSON Schema for structured output validation.
+	// When set, Claude's output MUST conform to this schema.
+	// Requires OutputFormat to be "json" for best results.
+	//
+	// If the output does not match the schema, the API may return an error
+	// or Claude may retry to produce conforming output (behavior depends on
+	// the Stromboli server configuration).
+	//
+	// Example:
+	//
+	//	&stromboli.ClaudeOptions{
+	//	    OutputFormat: "json",
+	//	    JSONSchema: `{
+	//	        "type": "object",
+	//	        "required": ["summary", "score"],
+	//	        "properties": {
+	//	            "summary": {"type": "string"},
+	//	            "score": {"type": "integer", "minimum": 0, "maximum": 100}
+	//	        }
+	//	    }`,
+	//	}
+	//
+	// See: https://json-schema.org/specification
+	JSONSchema string `json:"json_schema,omitempty"`
+
 	// Verbose enables detailed logging.
 	Verbose bool `json:"verbose,omitempty"`
 


### PR DESCRIPTION
## Summary

- Add `JSONSchema` field to `ClaudeOptions` for structured output validation
- When set, Claude's output must conform to the specified JSON Schema
- Requires `OutputFormat: "json"` for best results

Closes #11

## Changes

| File | Change |
|------|--------|
| `types.go` | Add `JSONSchema` field with comprehensive documentation |
| `client.go` | Add mapping in `toGeneratedRunRequest()` |
| `tests/unit/client_test.go` | Add 4 test cases including edge cases |

## Usage Example

```go
result, err := client.Run(ctx, &stromboli.RunRequest{
    Prompt: "Analyze this code",
    Claude: &stromboli.ClaudeOptions{
        OutputFormat: "json",
        JSONSchema: `{
            "type": "object",
            "required": ["summary", "score"],
            "properties": {
                "summary": {"type": "string"},
                "score": {"type": "integer", "minimum": 0, "maximum": 100}
            }
        }`,
    },
})
```

## Test plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Code reviewed by expert reviewer (2 rounds)

🤖 Generated with [Claude Code](https://claude.ai/code)