### PR TITLE
fix(ci): use REST API instead of gh CLI for cross-repo release lookup

### DIFF
--- a/.github/workflows/sync-stromboli.yml
+++ b/.github/workflows/sync-stromboli.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Resolve dispatch payload
         id: payload
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           # Three ways the version can arrive:
           #   1. repository_dispatch  → client_payload.version
@@ -44,7 +42,16 @@ jobs:
             VERSION="${{ inputs.version }}"
             SWAGGER_URL="${{ inputs.swagger_url }}"
             if [ -z "$VERSION" ]; then
-              VERSION=$(gh release view --repo tomblancdev/stromboli --json tagName --jq .tagName)
+              # Use the public REST API directly. We can't use `gh release
+              # view --repo tomblancdev/stromboli` here because GITHUB_TOKEN
+              # is scoped to THIS repo (stromboli-go) and gh's cross-repo
+              # reads fail with "release not found". The releases endpoint
+              # on public repos doesn't need auth.
+              VERSION=$(curl -fsSL https://api.github.com/repos/tomblancdev/stromboli/releases/latest | jq -r .tag_name)
+              if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+                echo "::error::Could not resolve latest stromboli release tag"
+                exit 1
+              fi
               echo "::notice::No version input — falling back to latest release: $VERSION"
             fi
           else


### PR DESCRIPTION
The fallback path in `workflow_dispatch` (when the version input is blank) called `gh release view --repo tomblancdev/stromboli` to grab the latest stromboli release tag. That fails with `release not found` because the default `GITHUB_TOKEN` in stromboli-go's runner is scoped to **this repo only** — gh's cross-repo authenticated reads come back as 404 even on public repos.

Switched to `curl` + the public REST API (`api.github.com/repos/tomblancdev/stromboli/releases/latest`), which doesn't need any auth for public releases. Added an explicit error if the API returns null so a transient outage produces a clean failure instead of an empty version cascading into bad URLs downstream.

## Surfaced

While manually triggering the workflow with `version=blank` to test the receiver path after enabling the 'Allow Actions to create PRs' repo setting on this repo. The dispatch path itself (the more important one — fired from stromboli's release workflow) is **not** affected, because that path reads the version from `client_payload.version` and never hits the fallback.

## Test plan

After merge, manually trigger https://github.com/tomblancdev/stromboli-go/actions/workflows/sync-stromboli.yml with version=blank — should now resolve to the latest stromboli tag (`v0.5.6-alpha` at the moment) and proceed to open the sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)