### PR TITLE
fix(receiver): use /releases endpoint to include prereleases

### DIFF
--- a/.github/workflows/sync-stromboli.yml
+++ b/.github/workflows/sync-stromboli.yml
@@ -45,9 +45,14 @@ jobs:
               # Use the public REST API directly. We can't use `gh release
               # view --repo tomblancdev/stromboli` here because GITHUB_TOKEN
               # is scoped to THIS repo (stromboli-go) and gh's cross-repo
-              # reads fail with "release not found". The releases endpoint
-              # on public repos doesn't need auth.
-              VERSION=$(curl -fsSL https://api.github.com/repos/tomblancdev/stromboli/releases/latest | jq -r .tag_name)
+              # reads fail with "release not found".
+              #
+              # We hit /releases (plural) rather than /releases/latest
+              # because stromboli currently only ships prereleases
+              # (-alpha tags) and /releases/latest 404s when no stable
+              # release exists. /releases returns everything (sorted
+              # newest first), so we just take [0].
+              VERSION=$(curl -fsSL https://api.github.com/repos/tomblancdev/stromboli/releases | jq -r '[.[] | select(.draft == false)][0].tag_name')
               if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
                 echo "::error::Could not resolve latest stromboli release tag"
                 exit 1


### PR DESCRIPTION
## Summary
- The cross-repo fallback I added in #23 used \`/releases/latest\`, which returns 404 when the upstream repo only has prereleases.
- Stromboli currently only cuts \`-alpha\` tags, so every manual \`workflow_dispatch\` with a blank version was failing at the resolve step.
- Switched to \`/releases\` (plural) and pick the newest non-draft entry, which works for both stable and prerelease repos.

Failing run that surfaced this: https://github.com/tomblancdev/stromboli-go/actions/runs/25218108199

## Test plan
- [ ] Merge, then re-run \`Sync OpenAPI from stromboli\` with no inputs
- [ ] Verify it resolves to the latest \`-alpha\` tag and opens a sync PR